### PR TITLE
Backtest speedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # AutoTrader Changelog
 
+## Version 0.6.7 (Unreleased)
+### Features
+- Major backtest speed improvements: over 50% reduction in backtest time for 
+  large, multi-asset backtests
+
 
 ## Version 0.6.6
 ### Features 

--- a/autotrader/autobot.py
+++ b/autotrader/autobot.py
@@ -551,7 +551,8 @@ class AutoTraderBot:
     def _create_backtest_results(self) -> dict:
         """Constructs backtest summary dictionary for further processing.
         """
-        backtest_results = BacktestResults(self._broker, self.instrument)
+        backtest_results = BacktestResults(self._broker, self.instrument, 
+                                           self._process_holding_history)
         backtest_results.indicators = self._strategy.indicators if \
             hasattr(self._strategy, 'indicators') else None
         backtest_results.data = self.data

--- a/autotrader/brokers/trading.py
+++ b/autotrader/brokers/trading.py
@@ -390,7 +390,6 @@ class Trade(Order):
         # Inherit order attributes
         if order:
             self._inheret_order(order)
-            order.status = 'filled'
             self.parent_id = order.id
         
     

--- a/autotrader/brokers/virtual/broker.py
+++ b/autotrader/brokers/virtual/broker.py
@@ -75,7 +75,6 @@ class Broker:
         self._equity_hist = []
         self._margin_hist = []
         self._time_hist = []
-        
         self.holdings = []
         
         # Last order and trade counts
@@ -518,7 +517,6 @@ class Broker:
         self._margin_hist.append(self.margin_available)
         self._time_hist.append(candle.name)
         
-        # TODO - dont record holdings when not plotting, or by specification
         holdings = self._get_holding_allocations()
         self.holdings.append(holdings)
         

--- a/autotrader/brokers/virtual/broker.py
+++ b/autotrader/brokers/virtual/broker.py
@@ -192,7 +192,7 @@ class Broker:
                      from_dict: str = 'open_orders') -> None:
         """Cancels the order.
         """
-        from_dict = getattr(self, from_dict)
+        from_dict = getattr(self, from_dict)[instrument]
         
         if instrument not in self.cancelled_orders: 
             self.cancelled_orders[instrument] = {}
@@ -216,7 +216,7 @@ class Broker:
             except KeyError:
                 trades = {}
         else:
-            # Return all currently open positions
+            # Return all currently open trades
             trades = {}
             for instr, instr_trades in all_trades.items():
                 trades.update(instr_trades)
@@ -362,7 +362,7 @@ class Broker:
         else:
             # Cancel order
             cancel_reason = "Insufficient margin to fill order."
-            self.cancel_order(order_id, cancel_reason)
+            self.cancel_order(instrument, order_id, cancel_reason)
     
     
     def _move_order(self, order: Order, from_dict: str = 'open_orders', 

--- a/autotrader/utilities.py
+++ b/autotrader/utilities.py
@@ -308,7 +308,10 @@ class BacktestResults:
                                                       instrument=instrument)
         
         # Construct account history
-        account_history = broker.account_history.copy()
+        account_history = pd.DataFrame(data={'NAV': broker._NAV_hist, 
+                                             'equity': broker._equity_hist, 
+                                             'margin': broker._margin_hist},
+                                       index=broker._time_hist)
         
         # Create history of holdings
         holdings = broker.holdings.copy()

--- a/autotrader/utilities.py
+++ b/autotrader/utilities.py
@@ -292,9 +292,19 @@ class BacktestResults:
         """Analyses backtest and creates summary of key details.
         """
         # Construct trade and order summaries
-        trades = BacktestResults.create_trade_summary(trades=broker.trades, 
+        all_trades = {}
+        for status in ['open', 'closed']:
+            trades = broker.get_trades(trade_status=status)
+            all_trades.update(trades)
+        
+        all_orders = {}
+        for status in ['pending', 'open', 'filled', 'cancelled']:
+            orders = broker.get_orders(order_status=status)
+            all_orders.update(orders)
+        
+        trades = BacktestResults.create_trade_summary(trades=all_trades, 
                                                       instrument=instrument)
-        orders = BacktestResults.create_trade_summary(orders=broker.orders, 
+        orders = BacktestResults.create_trade_summary(orders=all_orders, 
                                                       instrument=instrument)
         
         # Construct account history


### PR DESCRIPTION
Major speed up in backtesting, achieved through:
- organising trades and orders by status to speed up iteration over relevant dictionaries
- option not to post-process holding history