### PR TITLE
55 abstract broker

### DIFF
--- a/autotrader/autotrader.py
+++ b/autotrader/autotrader.py
@@ -13,9 +13,10 @@ from typing import Callable
 from threading import Thread
 from ast import literal_eval
 from scipy.optimize import brute
-from datetime import datetime, timedelta, timezone
 from autotrader.autoplot import AutoPlot
 from autotrader.autobot import AutoTraderBot
+from datetime import datetime, timedelta, timezone
+from autotrader.brokers.broker import AbstractBroker
 from autotrader.utilities import (
     read_yaml,
     get_broker_config,
@@ -903,7 +904,7 @@ class AutoTrader:
         self._scan_index = scan_index
         self._check_data_alignment = False
 
-    def run(self) -> None:
+    def run(self) -> AbstractBroker:
         """Performs essential checks and runs AutoTrader."""
         # Print Banner
         if int(self._verbosity) > 0:

--- a/autotrader/brokers/broker.py
+++ b/autotrader/brokers/broker.py
@@ -1,0 +1,64 @@
+from abc import ABC, abstractmethod
+from autotrader.brokers.trading import Order
+from autotrader.brokers.broker_utils import BrokerUtils
+
+
+class Broker(ABC):
+    @abstractmethod
+    def __init__(self, config: dict, utils: BrokerUtils = None) -> None:
+        """AutoTrader Broker Class constructor."""
+        pass
+
+    @abstractmethod
+    def __repr__(self):
+        return "AutoTrader Broker interface"
+
+    @abstractmethod
+    def __str__(self):
+        return "AutoTrader Broker interface"
+
+    @abstractmethod
+    def get_NAV(self, *args, **kwargs) -> float:
+        """Returns the net asset/liquidation value of the account."""
+        pass
+
+    @abstractmethod
+    def get_balance(self, *args, **kwargs) -> float:
+        """Returns account balance."""
+        pass
+
+    @abstractmethod
+    def place_order(self, order: Order, *args, **kwargs) -> None:
+        """Translate order and place via exchange API."""
+        pass 
+
+    @abstractmethod
+    def get_orders(self, instrument: str = None, *args, **kwargs) -> dict:
+        """Returns all pending orders (have not been filled) in the account."""
+        pass
+
+    @abstractmethod
+    def cancel_order(self, order_id: int, *args, **kwargs) -> None:
+        """Cancels order by order ID."""
+        pass
+
+    @abstractmethod
+    def get_trades(self, instrument: str = None, *args, **kwargs) -> dict:
+        """Returns the trades (fills) made by the account."""
+        pass
+
+    @abstractmethod
+    def get_positions(self, instrument: str = None, *args, **kwargs) -> dict:
+        """Gets the current positions open on the account.
+
+        Parameters
+        ----------
+        instrument : str, optional
+            The trading instrument name (symbol). The default is None.
+
+        Returns
+        -------
+        open_positions : dict
+            A dictionary containing details of the open positions.
+        """
+        pass

--- a/autotrader/brokers/broker.py
+++ b/autotrader/brokers/broker.py
@@ -30,7 +30,7 @@ class AbstractBroker(ABC):
     @abstractmethod
     def place_order(self, order: Order, *args, **kwargs) -> None:
         """Translate order and place via exchange API."""
-        pass 
+        pass
 
     @abstractmethod
     def get_orders(self, instrument: str = None, *args, **kwargs) -> dict:

--- a/autotrader/brokers/broker.py
+++ b/autotrader/brokers/broker.py
@@ -3,7 +3,7 @@ from autotrader.brokers.trading import Order
 from autotrader.brokers.broker_utils import BrokerUtils
 
 
-class Broker(ABC):
+class AbstractBroker(ABC):
     @abstractmethod
     def __init__(self, config: dict, utils: BrokerUtils = None) -> None:
         """AutoTrader Broker Class constructor."""

--- a/autotrader/brokers/ccxt/broker.py
+++ b/autotrader/brokers/ccxt/broker.py
@@ -1,12 +1,13 @@
 import ccxt
 from autotrader import AutoData
 from datetime import datetime, timezone
+from autotrader.brokers.broker import AbstractBroker
 from autotrader.brokers.broker_utils import OrderBook
 from autotrader.brokers.ccxt.utils import Utils, BrokerUtils
 from autotrader.brokers.trading import Order, Trade, Position
 
 
-class Broker:
+class Broker(AbstractBroker):
     def __init__(self, config: dict, utils: BrokerUtils = None) -> None:
         """AutoTrader Broker Class constructor."""
         # Unpack config and connect to broker-side API

--- a/autotrader/brokers/dydx/broker.py
+++ b/autotrader/brokers/dydx/broker.py
@@ -3,12 +3,13 @@ from decimal import Decimal
 from datetime import datetime
 from autotrader import AutoData
 from dydx3 import Client, constants
+from autotrader.brokers.broker import AbstractBroker
 from autotrader.brokers.broker_utils import OrderBook
 from autotrader.brokers.dydx.utils import Utils, BrokerUtils
 from autotrader.brokers.trading import Order, Position, Trade
 
 
-class Broker:
+class Broker(AbstractBroker):
     def __init__(self, config: dict, utils: BrokerUtils = None) -> None:
         """AutoTrader Broker Class constructor."""
         self._utils = utils if utils is not None else Utils()

--- a/autotrader/brokers/ib/broker.py
+++ b/autotrader/brokers/ib/broker.py
@@ -1,11 +1,12 @@
 import random
 import ib_insync
 import numpy as np
-from autotrader.brokers.trading import Order, IsolatedPosition, Position
 from autotrader.brokers.ib.utils import Utils
+from autotrader.brokers.broker import AbstractBroker
+from autotrader.brokers.trading import Order, IsolatedPosition, Position
 
 
-class Broker:
+class Broker(AbstractBroker):
     """AutoTrader-InteractiveBrokers API interface.
 
     Attributes

--- a/autotrader/brokers/oanda/broker.py
+++ b/autotrader/brokers/oanda/broker.py
@@ -9,11 +9,12 @@ import traceback
 import numpy as np
 import pandas as pd
 from autotrader import utilities, AutoData
+from autotrader.brokers.broker import AbstractBroker
 from autotrader.brokers.broker_utils import BrokerUtils
 from autotrader.brokers.trading import Order, IsolatedPosition, Position, Trade
 
 
-class Broker:
+class Broker(AbstractBroker):
     def __init__(self, oanda_config: dict, utils: BrokerUtils = None):
         """Create v20 context."""
         self.API = oanda_config["API"]

--- a/autotrader/brokers/virtual/broker.py
+++ b/autotrader/brokers/virtual/broker.py
@@ -5,14 +5,15 @@ import numpy as np
 import pandas as pd
 from decimal import Decimal
 from typing import Callable
-from datetime import date, datetime, timezone
 from autotrader.autodata import AutoData
+from datetime import date, datetime, timezone
 from autotrader.utilities import get_data_config
+from autotrader.brokers.broker import AbstractBroker
 from autotrader.brokers.broker_utils import OrderBook, BrokerUtils
 from autotrader.brokers.trading import Order, IsolatedPosition, Position, Trade
 
 
-class Broker:
+class Broker(AbstractBroker):
     """Autotrader Virtual Broker for simulated trading.
 
     Attributes

--- a/templates/newbroker/broker.py
+++ b/templates/newbroker/broker.py
@@ -1,4 +1,5 @@
 from autotrader.brokers.trading import Order
+from autotrader.brokers.broker import AbstractBroker
 from autotrader.brokers.broker_utils import BrokerUtils
 
 """
@@ -10,7 +11,7 @@ Notes:
 """
 
 
-class Broker:
+class Broker(AbstractBroker):
     def __init__(self, config: dict, utils: BrokerUtils = None) -> None:
         """AutoTrader Broker Class constructor."""
 


### PR DESCRIPTION
Addresses issue #55 by providing an abstract broker class implementation, `autotrader.brokers.broker.AbstractBroker`. All other broker instances inherits this class, enforcing the public methods of the [unified broker interface](https://autotrader.readthedocs.io/en/latest/broker/broker-interface.html).