### PR TITLE
Add handling for empty trades in position_histories_dict

### DIFF
--- a/autotrader/utilities.py
+++ b/autotrader/utilities.py
@@ -518,6 +518,10 @@ class TradeAnalysis:
             # Save result
             position_histories_dict[instrument] = net_position_hist
 
+        # If no trades, create empty dataframe
+        if len(instruments_traded) == 0:
+            position_histories_dict = {"empty": pd.DataFrame(index=account_history.index)}
+
         position_histories = pd.concat(position_histories_dict, axis=1)
         return position_histories
 


### PR DESCRIPTION
**Issue:** 

- If there are no trades, it will fail to concat and that will then fail all other processes like optimization (to find you the parameters you need to actually produce trades) on complex strategies

**Changes:** 

- Added checking for no trades to prevent crash and still provide a summary

This will allow you to continue optimization with a strategy that starts off with no trades..